### PR TITLE
add RegSpec::rbx() helper

### DIFF
--- a/src/long_mode/mod.rs
+++ b/src/long_mode/mod.rs
@@ -343,6 +343,11 @@ impl RegSpec {
     }
 
     #[inline]
+    pub const fn rbx() -> RegSpec {
+        RegSpec { bank: RegisterBank::Q, num: 3 }
+    }
+
+    #[inline]
     pub const fn rsi() -> RegSpec {
         RegSpec { bank: RegisterBank::Q, num: 6 }
     }


### PR DESCRIPTION
there's RegSpec::ebx() but not rbx :(