### PR TITLE
export `InstructionDisplayer`

### DIFF
--- a/src/long_mode/display.rs
+++ b/src/long_mode/display.rs
@@ -3272,6 +3272,8 @@ pub enum DisplayStyle {
     // ATT,
 }
 
+/// Implementation of [`Display`](fmt::Display) that renders instructions using a specified display
+/// style.
 pub struct InstructionDisplayer<'instr> {
     pub(crate) instr: &'instr Instruction,
     pub(crate) style: DisplayStyle,

--- a/src/long_mode/mod.rs
+++ b/src/long_mode/mod.rs
@@ -7,7 +7,7 @@ pub mod uarch;
 pub use crate::MemoryAccessSize;
 
 #[cfg(feature = "fmt")]
-pub use self::display::DisplayStyle;
+pub use self::display::{DisplayStyle, InstructionDisplayer};
 
 use core::cmp::PartialEq;
 use core::hint::unreachable_unchecked;

--- a/src/protected_mode/display.rs
+++ b/src/protected_mode/display.rs
@@ -3285,6 +3285,8 @@ pub enum DisplayStyle {
     // ATT,
 }
 
+/// Implementation of [`Display`](fmt::Display) that renders instructions using a specified display
+/// style.
 pub struct InstructionDisplayer<'instr> {
     pub(crate) instr: &'instr Instruction,
     pub(crate) style: DisplayStyle,

--- a/src/protected_mode/mod.rs
+++ b/src/protected_mode/mod.rs
@@ -7,7 +7,7 @@ pub mod uarch;
 pub use crate::MemoryAccessSize;
 
 #[cfg(feature = "fmt")]
-pub use self::display::DisplayStyle;
+pub use self::display::{DisplayStyle, InstructionDisplayer};
 
 use core::cmp::PartialEq;
 use core::hint::unreachable_unchecked;

--- a/src/real_mode/display.rs
+++ b/src/real_mode/display.rs
@@ -3285,6 +3285,8 @@ pub enum DisplayStyle {
     // ATT,
 }
 
+/// Implementation of [`Display`](fmt::Display) that renders instructions using a specified display
+/// style.
 pub struct InstructionDisplayer<'instr> {
     pub(crate) instr: &'instr Instruction,
     pub(crate) style: DisplayStyle,

--- a/src/real_mode/mod.rs
+++ b/src/real_mode/mod.rs
@@ -7,7 +7,7 @@ pub mod uarch;
 pub use crate::MemoryAccessSize;
 
 #[cfg(feature = "fmt")]
-pub use self::display::DisplayStyle;
+pub use self::display::{DisplayStyle, InstructionDisplayer};
 
 use core::cmp::PartialEq;
 use core::hint::unreachable_unchecked;


### PR DESCRIPTION
This makes generated docs refer to a type and show said type in the list of all structs rather than rustdoc showing gray text in return types.