### PR TITLE
Make invalid instruction constructors return invalid instructions

### DIFF
--- a/src/long_mode/mod.rs
+++ b/src/long_mode/mod.rs
@@ -3283,7 +3283,7 @@ impl Instruction {
     pub fn invalid() -> Instruction {
         Instruction {
             prefixes: Prefixes::new(0),
-            opcode: Opcode::NOP,
+            opcode: Opcode::Invalid,
             mem_size: 0,
             regs: [RegSpec::rax(); 4],
             scale: 0,

--- a/src/protected_mode/mod.rs
+++ b/src/protected_mode/mod.rs
@@ -3213,7 +3213,7 @@ impl Instruction {
     pub fn invalid() -> Instruction {
         Instruction {
             prefixes: Prefixes::new(0),
-            opcode: Opcode::NOP,
+            opcode: Opcode::Invalid,
             mem_size: 0,
             regs: [RegSpec::eax(); 4],
             scale: 0,

--- a/src/real_mode/mod.rs
+++ b/src/real_mode/mod.rs
@@ -3240,7 +3240,7 @@ impl Instruction {
     pub fn invalid() -> Instruction {
         Instruction {
             prefixes: Prefixes::new(0),
-            opcode: Opcode::NOP,
+            opcode: Opcode::Invalid,
             mem_size: 0,
             regs: [RegSpec::ax(); 4],
             scale: 0,


### PR DESCRIPTION
Currently, `Instruction::invalid()` constructors return `nop`s. I'm not sure why it was done this way, but it does create issues when trying to use `Instruction::invalid()` to represent invalid instructions in disassembly output, and is generally confusing and unexpected.

Some of the tests fail on this branch, but as far as I can tell, tag `2.1.1` (which this PR is based off of) also has the tests failing.