### PR TITLE
Fix verbose argument info for one-byte xchg.

### DIFF
--- a/src/long_mode/mod.rs
+++ b/src/long_mode/mod.rs
@@ -5894,7 +5894,7 @@ fn read_operands<
                 sink.record(
                     opcode_start,
                     opcode_start + 2,
-                    InnerDescription::RegisterNumber("zzz", reg, instruction.regs[0])
+                    InnerDescription::RegisterNumber("zzz", reg, instruction.regs[1])
                         .with_id(opcode_start + 1)
                 );
                 if instruction.prefixes.rex_unchecked().b() {

--- a/src/protected_mode/mod.rs
+++ b/src/protected_mode/mod.rs
@@ -5830,7 +5830,7 @@ fn read_operands<
                 sink.record(
                     opcode_start,
                     opcode_start + 2,
-                    InnerDescription::RegisterNumber("zzz", reg, instruction.regs[0])
+                    InnerDescription::RegisterNumber("zzz", reg, instruction.regs[1])
                         .with_id(opcode_start + 1)
                 );
                 sink.record(

--- a/src/real_mode/mod.rs
+++ b/src/real_mode/mod.rs
@@ -5852,7 +5852,7 @@ fn read_operands<
                 sink.record(
                     opcode_start,
                     opcode_start + 2,
-                    InnerDescription::RegisterNumber("zzz", reg, instruction.regs[0])
+                    InnerDescription::RegisterNumber("zzz", reg, instruction.regs[1])
                         .with_id(opcode_start + 1)
                 );
                 sink.record(


### PR DESCRIPTION
Step to reproduce: `yaxdis -v 97`

The bug: the instruction decodes correctly as `xchg eax, edi` but the verbose info has this line:
```
      111|                             `eax` (`zzz` selects register number 7)
```

With this patch:
```
      111|                             `edi` (`zzz` selects register number 7)
```